### PR TITLE
Added command 'init-config'

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -36,7 +36,8 @@ module Distribution.Client.Config (
     withProgramsFields,
     withProgramOptionsFields,
     userConfigDiff,
-    userConfigUpdate
+    userConfigUpdate,
+    createDefaultConfigFile
   ) where
 
 import Distribution.Client.Types
@@ -517,11 +518,8 @@ loadConfig verbosity configFileFlag userInstallFlag = addBaseConf $ do
     Nothing -> do
       notice verbosity $ "Config file path source is " ++ source ++ "."
       notice verbosity $ "Config file " ++ configFile ++ " not found."
-      notice verbosity $ "Writing default configuration to " ++ configFile
-      commentConf <- commentSavedConfig
-      initialConf <- initialSavedConfig
-      writeConfigFile configFile commentConf initialConf
-      return initialConf
+      createDefaultConfigFile verbosity configFile
+      loadConfig verbosity configFileFlag userInstallFlag
     Just (ParseOk ws conf) -> do
       unless (null ws) $ warn verbosity $
         unlines (map (showPWarning configFile) ws)
@@ -547,6 +545,13 @@ readConfigFile initial file = handleNotExists $
       if isDoesNotExistError ioe
         then return Nothing
         else ioError ioe
+
+createDefaultConfigFile :: Verbosity -> FilePath -> IO ()
+createDefaultConfigFile verbosity filePath = do
+  commentConf <- commentSavedConfig
+  initialConf <- initialSavedConfig
+  notice verbosity $ "Writing default configuration to " ++ filePath
+  writeConfigFile filePath commentConf initialConf
 
 writeConfigFile :: FilePath -> SavedConfig -> SavedConfig -> IO ()
 writeConfigFile file comments vals = do

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -21,6 +21,7 @@ module Distribution.Client.Setup
     , installCommand, InstallFlags(..), installOptions, defaultInstallFlags
     , listCommand, ListFlags(..)
     , updateCommand
+    , initConfigCommand, InitConfigFlags(..)
     , upgradeCommand
     , uninstallCommand
     , infoCommand, InfoFlags(..)
@@ -165,6 +166,7 @@ globalCommand commands = CommandUI {
           [ "help"
           , "update"
           , "install"
+          , "init-config"
           , "fetch"
           , "list"
           , "info"
@@ -207,6 +209,7 @@ globalCommand commands = CommandUI {
         [ startGroup "global"
         , addCmd "update"
         , addCmd "install"
+        , addCmd "init-config"
         , par
         , addCmd "help"
         , addCmd "info"
@@ -767,6 +770,40 @@ freezeCommand = CommandUI {
                          freezeShadowPkgs       (\v flags -> flags { freezeShadowPkgs       = v })
                          freezeStrongFlags      (\v flags -> flags { freezeStrongFlags      = v })
 
+  }
+
+-- ------------------------------------------------------------
+-- * Init-config command
+-- ------------------------------------------------------------
+
+data InitConfigFlags = InitConfigFlags {
+    initConfigVerbose :: Flag Verbosity,
+    initConfigForce   :: Flag Bool
+  }
+  deriving Show
+
+defaultInitConfigFlags :: InitConfigFlags
+defaultInitConfigFlags = InitConfigFlags {
+    initConfigVerbose  = Flag normal,
+    initConfigForce    = Flag False
+  }
+
+initConfigCommand :: CommandUI InitConfigFlags
+initConfigCommand = CommandUI {
+    commandName         = "init-config",
+    commandSynopsis     = "Create default config file if it doesn't already exist.",
+    commandDescription  = Just $ \_ ->
+        "Create default config file if it doesn't already exist.\n",
+    commandNotes        = Nothing,
+    commandUsage        = usageFlags "init-config",
+    commandDefaultFlags = defaultInitConfigFlags,
+    commandOptions      = \_ -> [
+      optionVerbosity initConfigVerbose (\v flags -> flags { initConfigVerbose = v })
+    , option ['f'] ["force"]
+       "Overwrite file even if it already exists."
+       initConfigForce (\v flags -> flags { initConfigForce = v })
+       trueArg
+      ]
   }
 
 -- ------------------------------------------------------------

--- a/cabal-install/tests/PackageTests.hs
+++ b/cabal-install/tests/PackageTests.hs
@@ -36,6 +36,7 @@ import PackageTests.PackageTester ( TestsPaths(..)
 import qualified PackageTests.Exec.Check
 import qualified PackageTests.Freeze.Check
 import qualified PackageTests.MultipleSource.Check
+import qualified PackageTests.InitConfig.Check
 
 -- List of tests to run. Each test will be called with the path to the
 -- cabal binary to use.
@@ -44,6 +45,7 @@ tests paths = testGroup "Package Tests" $
     [ testGroup "Freeze"         $ PackageTests.Freeze.Check.tests         paths
     , testGroup "Exec"           $ PackageTests.Exec.Check.tests           paths
     , testGroup "MultipleSource" $ PackageTests.MultipleSource.Check.tests paths
+    , testGroup "InitConfig"     $ PackageTests.InitConfig.Check.tests     paths
     ]
 
 cabalProgram :: Program

--- a/cabal-install/tests/PackageTests/InitConfig/Check.hs
+++ b/cabal-install/tests/PackageTests/InitConfig/Check.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module PackageTests.InitConfig.Check
+       ( tests
+       ) where
+
+import PackageTests.PackageTester
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Control.Exception.Extensible as E
+import System.Directory (removeFile)
+import System.FilePath ((</>))
+import System.IO.Error (isDoesNotExistError)
+
+dir :: FilePath
+dir = packageTestsDirectory 
+
+tests :: TestsPaths -> [TestTree]
+tests paths =
+    [ testCase "runs without error" $ do
+          removeCabalConfig
+          result <- cabal_initconfig paths dir []
+          assertInitConfigSucceeded result
+
+    , testCase "doesn't overwrite without -f" $ do
+          removeCabalConfig
+          _      <- cabal_initconfig paths dir []
+          result <- cabal_initconfig paths dir []
+          assertInitConfigFailed result
+
+    , testCase "overwrites with -f" $ do
+          removeCabalConfig
+          _      <- cabal_initconfig paths dir []
+          result <- cabal_initconfig paths dir ["-f"]
+          assertInitConfigSucceeded result
+    ]
+
+removeCabalConfig :: IO ()
+removeCabalConfig = do
+    removeFile (dir </> "cabal-config")
+    `E.catch` \ (e :: IOError) ->
+        if isDoesNotExistError e
+        then return ()
+        else E.throw e

--- a/cabal-install/tests/PackageTests/InitConfig/my.cabal
+++ b/cabal-install/tests/PackageTests/InitConfig/my.cabal
@@ -1,0 +1,21 @@
+name:           my
+version:        0.1
+license:        BSD3
+cabal-version:  >= 1.20.0
+build-type:     Simple
+
+library
+    exposed-modules:    Foo
+    build-depends:      base
+
+test-suite test-Foo
+    type:   exitcode-stdio-1.0
+    hs-source-dirs: tests
+    main-is:    test-Foo.hs
+    build-depends: base, my, test-framework
+
+benchmark bench-Foo
+    type:   exitcode-stdio-1.0
+    hs-source-dirs: benchmarks
+    main-is:    benchmark-Foo.hs
+    build-depends: base, my, criterion

--- a/cabal-install/tests/PackageTests/PackageTester.hs
+++ b/cabal-install/tests/PackageTests/PackageTester.hs
@@ -29,6 +29,7 @@ module PackageTests.PackageTester
     , cabal_freeze
     , cabal_install
     , cabal_sandbox
+    , cabal_initconfig
     , run
 
     -- * Test helpers
@@ -38,6 +39,8 @@ module PackageTests.PackageTester
     , assertFreezeSucceeded
     , assertInstallSucceeded
     , assertSandboxSucceeded
+    , assertInitConfigSucceeded
+    , assertInitConfigFailed
     ) where
 
 import qualified Control.Exception.Extensible as E
@@ -66,6 +69,7 @@ data Success = Failure
              | CleanSuccess
              | ExecSuccess
              | FreezeSuccess
+             | InitConfigSuccess
              | InstallSuccess
              | SandboxSuccess
              deriving (Eq, Show)
@@ -126,6 +130,12 @@ cabal_freeze :: TestsPaths -> FilePath -> [String] -> IO Result
 cabal_freeze paths dir args = do
     res <- cabal paths dir (["freeze"] ++ args)
     return $ recordRun res FreezeSuccess nullResult
+
+-- | Run the init-config command and return its result.
+cabal_initconfig :: TestsPaths -> FilePath -> [String] -> IO Result
+cabal_initconfig paths dir args = do
+    res <- cabal paths dir (["init-config"] ++ args)
+    return $ recordRun res InitConfigSuccess nullResult
 
 -- | Run the install command and return its result.
 cabal_install :: TestsPaths -> FilePath -> [String] -> IO Result
@@ -214,6 +224,19 @@ assertSandboxSucceeded result = unless (successful result) $
     assertFailure $
     "expected: \'cabal sandbox\' should succeed\n" ++
     "  output: " ++ outputText result
+
+assertInitConfigSucceeded :: Result -> Assertion
+assertInitConfigSucceeded result = unless (successful result) $
+    assertFailure $
+    "expected: \'cabal init-config\' should succeed\n" ++
+    "  output: " ++ outputText result
+
+assertInitConfigFailed :: Result -> Assertion
+assertInitConfigFailed result = when (successful result) $
+    assertFailure $
+    "expected: \'cabal init-config\' should fail\n" ++
+    "  output: " ++ outputText result
+
 
 ------------------------------------------------------------------------
 -- Verbosity


### PR DESCRIPTION
init-config creates a default config file if it doesn't already exist.

If --config-file is set, then that file will be written.
If -f or --force is used, then the file will be overwritten if it
already exists.
